### PR TITLE
Add customizable search method

### DIFF
--- a/Sources/Elasticsearch/Api/Document.swift
+++ b/Sources/Elasticsearch/Api/Document.swift
@@ -42,6 +42,17 @@ extension ESClient : ESIndexer {
         return try search(parameters: requestParams, body: body)
     }
     
+    public func search(index: String? = nil, type: String? = nil, body: JSONStringRepresentable, parameters: ESParams = [:]) throws -> ESResponse {
+        var requestParams = parameters
+        if let index = index {
+            requestParams["index"] = ESParam(index)
+        }
+        if let type = type {
+            requestParams["type"] = ESParam(type)
+        }
+        return try search(parameters: requestParams, body: body)
+    }
+    
     // MARK: - Index
     
     public func index(parameters: ESParams = [:], body: JSONStringRepresentable) throws -> ESResponse {


### PR DESCRIPTION
Previously, we have to send a request with `ESIndexNameable`.
To avoid breaking the existing code, I added this method and will use it for searching in Elastic Cloud.